### PR TITLE
Fix: CountVectorizer Upper Case Issue on Unicode Characters

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -581,6 +581,17 @@ Changelog
   and the boundaries are not set.
   :pr:`22027` by `Marie Lanternier <mlant>`.
 
+....................
+
+- |Fix| :func:`_preprocess` now converts special unicode characters such as '™️', '℠', 'Á', 
+  'È', 'Ç', 'Ñ', 'Û' to lowercase (i.e. tm, sm, a, e, c, n, u, respectively).
+  :pr:`3` by :user:`Pasa Ali Aslan <pasaaliaslan>`, :user:`Albert Li <lialber2>`, 
+  and :user:`Jack Woodger <jwoodger>`.
+
+:mod:`sklearn.feature_extraction`
+
+....................
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -456,6 +456,21 @@ def test_countvectorizer_uppercase_in_vocab():
     assert not record
 
 
+def test_countvectorizer_unicode_character_in_vocab():
+    vocabulary = ['Problematic™.', 'THIS IS NOT']
+    vectorizer = CountVectorizer(
+        lowercase=True,
+        strip_accents='unicode'
+    )
+
+    vectorizer.fit_transform(vocabulary)
+
+    expected = ['is', 'not', 'problematictm', 'this']
+    actual = vectorizer.get_feature_names_out()
+
+    assert_array_equal(actual, expected)
+
+
 def test_tf_transformer_feature_names_out():
     """Check get_feature_names_out for TfidfTransformer"""
     X = [[1, 1, 1], [1, 1, 0], [1, 0, 0]]

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -471,6 +471,23 @@ def test_countvectorizer_unicode_character_in_vocab():
     assert_array_equal(actual, expected)
 
 
+def test_countvectorizer_unicode_lowercase():
+    vocabulary = ['™️', '℠', 'Á', 'È', 'Ç', 'Ñ', 'Û']
+
+    vectorizer = CountVectorizer(
+        lowercase=True,
+        strip_accents='unicode',
+        # This test requires that individual letters are tokenized.
+        token_pattern=r'(?u)\b\w+\b'
+    )
+    vectorizer.fit_transform(vocabulary)
+
+    expected = ['a', 'c', 'e', 'n', 'sm', 'tm', 'u']
+    actual = vectorizer.get_feature_names_out()
+
+    assert_array_equal(actual, expected)
+
+
 def test_tf_transformer_feature_names_out():
     """Check get_feature_names_out for TfidfTransformer"""
     X = [[1, 1, 1], [1, 1, 0], [1, 0, 0]]

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -67,10 +67,10 @@ def _preprocess(doc, accent_function=None, lower=False):
     doc: str
         preprocessed string
     """
-    if lower:
-        doc = doc.lower()
     if accent_function is not None:
         doc = accent_function(doc)
+    if lower:
+        doc = doc.lower()
     return doc
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes scikit-learn/scikit-learn#21207

#### What does this implement/fix?
CountVectorizer couldn't convert special unicode characters such as ™️, ℠, Á, È, Ç, Ñ, Û, to lowercase (i.e. to tm, sm, a, e, c, n, u, respectively), due to a wrong algorithmic order of events: the code was trying to convert all letters to lowercase then get rid of any accents in them. However, as python's lower() function cannot recognize such unicode characters, they remained unchanged.

This PR is for the bug fix that implements support for converting such characters to lowercase by getting rid of their accents (e.g. ™️ is converted to TM) first, then applying python's lower() function on them.