### PR TITLE
 Fix: DeprecationWarning for negative y_true values in ndcg_score

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -424,6 +424,12 @@ Changelog
 - |Fix| :func:`metrics.silhouette_score` now supports integer input for precomputed
   distances. :pr:`22108` by `Thomas Fan`_.
 
+- |Fix| :func:`metrics.ndcg_score` will now trigger a warning when the y_true
+  value contains a negative value. It will allow the user to still use negative
+  values, but the result may not be between 0 and 1.
+  :pr:`4` by :user:`Conroy Trinh <trinhcon>`, :user:`Ciaran Hogan <ciaran-h>`
+  and :user:`Victor Ko <VKo232>`
+
 :mod:`sklearn.manifold`
 .......................
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -427,7 +427,7 @@ Changelog
 - |Fix| :func:`metrics.ndcg_score` will now trigger a warning when the y_true
   value contains a negative value. It will allow the user to still use negative
   values, but the result may not be between 0 and 1.
-  :pr:`4` by :user:`Conroy Trinh <trinhcon>`, :user:`Ciaran Hogan <ciaran-h>`
+  :pr:`5` by :user:`Conroy Trinh <trinhcon>`, :user:`Ciaran Hogan <ciaran-h>`
   and :user:`Victor Ko <VKo232>`
 
 :mod:`sklearn.manifold`

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1533,7 +1533,9 @@ def ndcg_score(y_true, y_score, *, k=None, sample_weight=None, ignore_ties=False
     ----------
     y_true : ndarray of shape (n_samples, n_labels)
         True targets of multilabel classification, or true scores of entities
-        to be ranked.
+        to be ranked. Negative values in y_true may result in an output
+        that is not between 0 and 1. These negative values are deprecated, and
+        may cause an error in the future.
 
     y_score : ndarray of shape (n_samples, n_labels)
         Target scores, can either be probability estimates, confidence values,
@@ -1617,6 +1619,20 @@ def ndcg_score(y_true, y_score, *, k=None, sample_weight=None, ignore_ties=False
     check_consistent_length(y_true, y_score, sample_weight)
     _check_dcg_target_type(y_true)
     gain = _ndcg_sample_scores(y_true, y_score, k=k, ignore_ties=ignore_ties)
+
+    if (isinstance(y_true, np.ndarray)):
+        if (y_true.min() < 0):
+            warnings.warn(
+                "ndcg_score should not use negative y_true values",
+                DeprecationWarning,
+            )
+    else:
+        for value in y_true:
+            if (value < 0):
+                warnings.warn(
+                    "ndcg_score should not use negative y_true values",
+                    DeprecationWarning,
+                )
     return np.average(gain, weights=sample_weight)
 
 

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1923,3 +1923,24 @@ def test_top_k_accuracy_score_error(y_true, labels, msg):
     )
     with pytest.raises(ValueError, match=msg):
         top_k_accuracy_score(y_true, y_score, k=2, labels=labels)
+
+
+def test_ndcg_negative_ndarray_warn():
+    y_true  = np.array([-0.89, -0.53, -0.47, 0.39, 0.56]).reshape(1,-1)
+    y_score = np.array([0.07,0.31,0.75,0.33,0.27]).reshape(1,-1)
+    expected_message = "ndcg_score should not use negative y_true values"
+    with pytest.warns(DeprecationWarning, match=expected_message):
+        ndcg_score(y_true, y_score)
+
+
+def test_ndcg_negative_output():
+    y_true  = np.array([-0.89, -0.53, -0.47, 0.39, 0.56]).reshape(1,-1)
+    y_score = np.array([0.07,0.31,0.75,0.33,0.27]).reshape(1,-1)
+    assert ndcg_score(y_true, y_score) == pytest.approx(396.0329)
+
+
+def test_ndcg_positive_ndarray():
+    y_true  = np.array([0.11, 0.47, 0.53, 1.39, 1.56]).reshape(1,-1)
+    y_score = np.array([1.07, 1.31, 1.75, 1.33, 1.27]).reshape(1,-1)
+    with pytest.warns(None):
+        ndcg_score(y_true, y_score)


### PR DESCRIPTION
#### Reference Issues/PRs
negative ndcg_score for y_true values


#### What does this implement/fix? Explain your changes.
Merges the ndcg_score with negative y_true values, will fire a
warning if negative values are used.



- [x]   @ciaran-h Does not need to commit any more changes
- [x]   @ciaran-h has reviewed
- [x]   @VKo232 Does not need to commit any more changes
- [x]   @VKo232 has reviewed
- [x]   @trinhcon has reviewed
