### PR TITLE
FIX #17639 and #21207

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -424,6 +424,12 @@ Changelog
 - |Fix| :func:`metrics.silhouette_score` now supports integer input for precomputed
   distances. :pr:`22108` by `Thomas Fan`_.
 
+- |Fix| :func:`metrics.ndcg_score` will now trigger a warning when the y_true
+  value contains a negative value. It will allow the user to still use negative
+  values, but the result may not be between 0 and 1.
+  :pr:`4` by :user:`Conroy Trinh <trinhcon>`, :user:`Ciaran Hogan <ciaran-h>`
+  and :user:`Victor Ko <VKo232>`
+
 :mod:`sklearn.manifold`
 .......................
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -427,7 +427,7 @@ Changelog
 - |Fix| :func:`metrics.ndcg_score` will now trigger a warning when the y_true
   value contains a negative value. It will allow the user to still use negative
   values, but the result may not be between 0 and 1.
-  :pr:`4` by :user:`Conroy Trinh <trinhcon>`, :user:`Ciaran Hogan <ciaran-h>`
+  :pr:`5` by :user:`Conroy Trinh <trinhcon>`, :user:`Ciaran Hogan <ciaran-h>`
   and :user:`Victor Ko <VKo232>`
 
 :mod:`sklearn.manifold`

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -581,6 +581,17 @@ Changelog
   and the boundaries are not set.
   :pr:`22027` by `Marie Lanternier <mlant>`.
 
+....................
+
+- |Fix| :func:`_preprocess` now converts special unicode characters such as '™️', '℠', 'Á', 
+  'È', 'Ç', 'Ñ', 'Û' to lowercase (i.e. tm, sm, a, e, c, n, u, respectively).
+  :pr:`3` by :user:`Pasa Ali Aslan <pasaaliaslan>`, :user:`Albert Li <lialber2>`, 
+  and :user:`Jack Woodger <jwoodger>`.
+
+:mod:`sklearn.feature_extraction`
+
+....................
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -456,6 +456,21 @@ def test_countvectorizer_uppercase_in_vocab():
     assert not record
 
 
+def test_countvectorizer_unicode_character_in_vocab():
+    vocabulary = ['Problematic™.', 'THIS IS NOT']
+    vectorizer = CountVectorizer(
+        lowercase=True,
+        strip_accents='unicode'
+    )
+
+    vectorizer.fit_transform(vocabulary)
+
+    expected = ['is', 'not', 'problematictm', 'this']
+    actual = vectorizer.get_feature_names_out()
+
+    assert_array_equal(actual, expected)
+
+
 def test_tf_transformer_feature_names_out():
     """Check get_feature_names_out for TfidfTransformer"""
     X = [[1, 1, 1], [1, 1, 0], [1, 0, 0]]

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -471,6 +471,23 @@ def test_countvectorizer_unicode_character_in_vocab():
     assert_array_equal(actual, expected)
 
 
+def test_countvectorizer_unicode_lowercase():
+    vocabulary = ['™️', '℠', 'Á', 'È', 'Ç', 'Ñ', 'Û']
+
+    vectorizer = CountVectorizer(
+        lowercase=True,
+        strip_accents='unicode',
+        # This test requires that individual letters are tokenized.
+        token_pattern=r'(?u)\b\w+\b'
+    )
+    vectorizer.fit_transform(vocabulary)
+
+    expected = ['a', 'c', 'e', 'n', 'sm', 'tm', 'u']
+    actual = vectorizer.get_feature_names_out()
+
+    assert_array_equal(actual, expected)
+
+
 def test_tf_transformer_feature_names_out():
     """Check get_feature_names_out for TfidfTransformer"""
     X = [[1, 1, 1], [1, 1, 0], [1, 0, 0]]

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -67,10 +67,10 @@ def _preprocess(doc, accent_function=None, lower=False):
     doc: str
         preprocessed string
     """
-    if lower:
-        doc = doc.lower()
     if accent_function is not None:
         doc = accent_function(doc)
+    if lower:
+        doc = doc.lower()
     return doc
 
 

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1533,8 +1533,7 @@ def ndcg_score(y_true, y_score, *, k=None, sample_weight=None, ignore_ties=False
     ----------
     y_true : ndarray of shape (n_samples, n_labels)
         True targets of multilabel classification, or true scores of entities
-        to be ranked. y_true must have non-negative values or the result may
-        not be between 0 and 1
+        to be ranked.
 
     y_score : ndarray of shape (n_samples, n_labels)
         Target scores, can either be probability estimates, confidence values,
@@ -1613,9 +1612,6 @@ def ndcg_score(y_true, y_score, *, k=None, sample_weight=None, ignore_ties=False
     0.5
 
     """
-    if (y_true.min() < 0):
-        raise DeprecationWarning("ndcg_score should not use negative y_true values")
-
     y_true = check_array(y_true, ensure_2d=False)
     y_score = check_array(y_score, ensure_2d=False)
     check_consistent_length(y_true, y_score, sample_weight)

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1533,7 +1533,8 @@ def ndcg_score(y_true, y_score, *, k=None, sample_weight=None, ignore_ties=False
     ----------
     y_true : ndarray of shape (n_samples, n_labels)
         True targets of multilabel classification, or true scores of entities
-        to be ranked.
+        to be ranked. y_true must have non-negative values or the result may
+        not be between 0 and 1
 
     y_score : ndarray of shape (n_samples, n_labels)
         Target scores, can either be probability estimates, confidence values,
@@ -1612,6 +1613,9 @@ def ndcg_score(y_true, y_score, *, k=None, sample_weight=None, ignore_ties=False
     0.5
 
     """
+    if (y_true.min() < 0):
+        raise DeprecationWarning("ndcg_score should not use negative y_true values")
+
     y_true = check_array(y_true, ensure_2d=False)
     y_score = check_array(y_score, ensure_2d=False)
     check_consistent_length(y_true, y_score, sample_weight)

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1533,7 +1533,9 @@ def ndcg_score(y_true, y_score, *, k=None, sample_weight=None, ignore_ties=False
     ----------
     y_true : ndarray of shape (n_samples, n_labels)
         True targets of multilabel classification, or true scores of entities
-        to be ranked.
+        to be ranked. Negative values in y_true may result in an output
+        that is not between 0 and 1. These negative values are deprecated, and
+        may cause an error in the future.
 
     y_score : ndarray of shape (n_samples, n_labels)
         Target scores, can either be probability estimates, confidence values,
@@ -1617,6 +1619,20 @@ def ndcg_score(y_true, y_score, *, k=None, sample_weight=None, ignore_ties=False
     check_consistent_length(y_true, y_score, sample_weight)
     _check_dcg_target_type(y_true)
     gain = _ndcg_sample_scores(y_true, y_score, k=k, ignore_ties=ignore_ties)
+
+    if (isinstance(y_true, np.ndarray)):
+        if (y_true.min() < 0):
+            warnings.warn(
+                "ndcg_score should not use negative y_true values",
+                DeprecationWarning,
+            )
+    else:
+        for value in y_true:
+            if (value < 0):
+                warnings.warn(
+                    "ndcg_score should not use negative y_true values",
+                    DeprecationWarning,
+                )
     return np.average(gain, weights=sample_weight)
 
 

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1923,3 +1923,24 @@ def test_top_k_accuracy_score_error(y_true, labels, msg):
     )
     with pytest.raises(ValueError, match=msg):
         top_k_accuracy_score(y_true, y_score, k=2, labels=labels)
+
+
+def test_ndcg_negative_ndarray_warn():
+    y_true  = np.array([-0.89, -0.53, -0.47, 0.39, 0.56]).reshape(1,-1)
+    y_score = np.array([0.07,0.31,0.75,0.33,0.27]).reshape(1,-1)
+    expected_message = "ndcg_score should not use negative y_true values"
+    with pytest.warns(DeprecationWarning, match=expected_message):
+        ndcg_score(y_true, y_score)
+
+
+def test_ndcg_negative_output():
+    y_true  = np.array([-0.89, -0.53, -0.47, 0.39, 0.56]).reshape(1,-1)
+    y_score = np.array([0.07,0.31,0.75,0.33,0.27]).reshape(1,-1)
+    assert ndcg_score(y_true, y_score) == pytest.approx(396.0329)
+
+
+def test_ndcg_positive_ndarray():
+    y_true  = np.array([0.11, 0.47, 0.53, 1.39, 1.56]).reshape(1,-1)
+    y_score = np.array([1.07, 1.31, 1.75, 1.33, 1.27]).reshape(1,-1)
+    with pytest.warns(None):
+        ndcg_score(y_true, y_score)


### PR DESCRIPTION


#### Reference Issues/PRs
Fixes #17639 and #21207


#### What does this implement/fix? Explain your changes.
For #17639, the fix merges the ndcg_score with negative y_true values, and will fire a warning if negative values are used.
For #21207, the fix first calls strip_accents and then calls lower(), instead of the opposite order.
