### PR TITLE
Fix/search cv

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -609,7 +609,7 @@ Changelog
   :user:`Jack Woodger <jwoodger>`, :user:`Ciaran Hogan <ciaran-h>`, :user:`Victor Ko <VKo232>`,
   and :user:`Conroy Trinh <trinhcon>`
 
-:mod:`sklear.model_selection`
+:mod:`sklearn.model_selection`
 
 ....................
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -598,6 +598,19 @@ Changelog
 
 ....................
 
+- |Fix| :func:`_select_best_index` now returns the best_index according to 
+  the lexicographical order of the params instead of the order params appear 
+  in the list. :pr:`7` by :user:`Pasa Ali Aslan <pasaaliaslan>`, :user:`Albert Li <lialber2>`, 
+  :user:`Jack Woodger <jwoodger>`, :user:`Ciaran Hogan <ciaran-h>`, :user:`Victor Ko <VKo232>`,
+  and :user:`Conroy Trinh <trinhcon>`
+
+- |Enhancement| :add:`_hash_param_values` method for calculating the lexicographical
+  order of params. :pr:`7` by :user:`Pasa Ali Aslan <pasaaliaslan>`, :user:`Albert Li <lialber2>`, 
+  :user:`Jack Woodger <jwoodger>`, :user:`Ciaran Hogan <ciaran-h>`, :user:`Victor Ko <VKo232>`,
+  and :user:`Conroy Trinh <trinhcon>`
+
+....................
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -600,14 +600,16 @@ Changelog
 
 - |Fix| :func:`_select_best_index` now returns the best_index according to 
   the lexicographical order of the params instead of the order params appear 
-  in the list. :pr:`7` by :user:`Pasa Ali Aslan <pasaaliaslan>`, :user:`Albert Li <lialber2>`, 
+  in the list. :pr:`8` by :user:`Pasa Ali Aslan <pasaaliaslan>`, :user:`Albert Li <lialber2>`, 
   :user:`Jack Woodger <jwoodger>`, :user:`Ciaran Hogan <ciaran-h>`, :user:`Victor Ko <VKo232>`,
   and :user:`Conroy Trinh <trinhcon>`
 
 - |Enhancement| :add:`_hash_param_values` method for calculating the lexicographical
-  order of params. :pr:`7` by :user:`Pasa Ali Aslan <pasaaliaslan>`, :user:`Albert Li <lialber2>`, 
+  order of params. :pr:`8` by :user:`Pasa Ali Aslan <pasaaliaslan>`, :user:`Albert Li <lialber2>`, 
   :user:`Jack Woodger <jwoodger>`, :user:`Ciaran Hogan <ciaran-h>`, :user:`Victor Ko <VKo232>`,
   and :user:`Conroy Trinh <trinhcon>`
+
+:mod:`sklear.model_selection`
 
 ....................
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -346,6 +346,13 @@ def _check_refit(search_cv, attr):
         )
 
 
+def _hash_param_names(param):
+    res = ""
+    for entry in param:
+        res += str(param[entry])
+    return res
+
+
 def _estimator_has(attr):
     """Check if we can delegate a method to the underlying estimator.
 
@@ -744,7 +751,15 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             if best_index < 0 or best_index >= len(results["params"]):
                 raise IndexError("best_index_ index out of range")
         else:
-            best_index = results[f"rank_test_{refit_metric}"].argmin()
+            min_hash = ""
+            best_index = 0
+            params = results["params"]
+            for i in range(len(results["params"])):
+                if results[f"rank_test_{refit_metric}"][i] == 1:
+                    param_hash = _hash_param_names(params[i])
+                    if not min_hash or param_hash < min_hash:
+                        best_index = i
+                        min_hash = param_hash
         return best_index
 
     def fit(self, X, y=None, *, groups=None, **fit_params):

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -346,7 +346,11 @@ def _check_refit(search_cv, attr):
         )
 
 
-def _hash_param_names(param):
+def _hash_param_values(param):
+    """Hashes the values of a param dictionary into a single string.
+
+    Used to compare sets of hyper parameters lexicographically.
+    """
     res = ""
     for entry in param:
         res += str(param[entry])
@@ -756,7 +760,7 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             params = results["params"]
             for i in range(len(results["params"])):
                 if results[f"rank_test_{refit_metric}"][i] == 1:
-                    param_hash = _hash_param_names(params[i])
+                    param_hash = _hash_param_values(params[i])
                     if not min_hash or param_hash < min_hash:
                         best_index = i
                         min_hash = param_hash

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -1734,7 +1734,7 @@ class RandomizedSearchCV(BaseSearchCV):
     >>> clf = RandomizedSearchCV(logistic, distributions, random_state=0)
     >>> search = clf.fit(iris.data, iris.target)
     >>> search.best_params_
-    {'C': 2..., 'penalty': 'l1'}
+    {'C': 1..., 'penalty': 'l2'}
     """
 
     _required_parameters = ["estimator", "param_distributions"]

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -2593,6 +2593,118 @@ def test_randomized_search_cv_linearSVC_multiple_rank1_same_params():
     assert (actual1 == expected and actual2 == expected)
 
 
+def test_grid_search_cv_linearSVR_multiple_rank1_same_params():
+    iris = datasets.load_iris()
+
+    params1 = {
+        'epsilon': [0, 7],
+        'tol': [1, 8],
+        'C': [2, 9],
+        'loss': ['epsilon_insensitive'],
+        'fit_intercept': [True],
+        'intercept_scaling': [3],
+        'dual': [True],
+        'verbose': [4],
+        'random_state': [5],
+        'max_iter': [6]
+    }
+
+    params2 = {
+        'epsilon': [7, 0],
+        'C': [9, 2],
+        'loss': ['epsilon_insensitive'],
+        'random_state': [5],
+        'tol': [8, 1],
+        'fit_intercept': [True],
+        'max_iter': [6],
+        'intercept_scaling': [3],
+        'dual': [True],
+        'verbose': [4],
+    }
+
+    svr1 = svm.LinearSVR()
+    clf1 = GridSearchCV(svr1, params1, return_train_score=True)
+    clf1.fit(iris.data, iris.target)
+
+    svr2 = svm.LinearSVR()
+    clf2 = GridSearchCV(svr2, params2, return_train_score=True)
+    clf2.fit(iris.data, iris.target)
+
+    expected = {
+        'C': 2,
+        'dual': True,
+        'epsilon': 0,
+        'fit_intercept': True,
+        'intercept_scaling': 3,
+        'loss': 'epsilon_insensitive',
+        'max_iter': 6,
+        'random_state': 5,
+        'tol': 1,
+        'verbose': 4
+    }
+
+    actual1 = clf1.best_params_
+    actual2 = clf2.best_params_
+
+    assert (actual1 == expected and actual2 == expected)
+
+
+def test_randomized_search_cv_linearSVR_multiple_rank1_same_params():
+    iris = datasets.load_iris()
+
+    params1 = {
+        'epsilon': [0, 7],
+        'tol': [1, 8],
+        'C': [2, 9],
+        'loss': ['epsilon_insensitive'],
+        'fit_intercept': [True],
+        'intercept_scaling': [3],
+        'dual': [True],
+        'verbose': [4],
+        'random_state': [5],
+        'max_iter': [6]
+    }
+
+    params2 = {
+        'epsilon': [7, 0],
+        'C': [9, 2],
+        'loss': ['epsilon_insensitive'],
+        'random_state': [5],
+        'tol': [8, 1],
+        'fit_intercept': [True],
+        'max_iter': [6],
+        'intercept_scaling': [3],
+        'dual': [True],
+        'verbose': [4],
+    }
+
+    svr1 = svm.LinearSVR()
+    clf1 = RandomizedSearchCV(svr1, params1, return_train_score=True)
+    clf1.fit(iris.data, iris.target)
+
+    svr2 = svm.LinearSVR()
+    clf2 = RandomizedSearchCV(svr2, params2, return_train_score=True)
+    clf2.fit(iris.data, iris.target)
+
+    expected = {
+        'verbose': 4, 
+        'tol': 1, 
+        'random_state': 5, 
+        'max_iter': 6, 
+        'loss': 'epsilon_insensitive', 
+        'intercept_scaling': 3, 
+        'fit_intercept': True, 
+        'epsilon': 0, 
+        'dual': True, 
+        'C': 2
+    }
+
+    actual1 = clf1.best_params_
+    actual2 = clf2.best_params_
+
+    assert (actual1 == expected and actual2 == expected)
+
+
 @pytest.mark.parametrize(
     "SearchCV, param_search",
     [(GridSearchCV, {"a": [0.1, 0.01]}), (RandomizedSearchCV, {"a": uniform(1, 3)})],

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -2847,6 +2847,124 @@ def test_randomized_search_cv_nuSVC_multiple_rank1_same_params():
     assert (actual1 == expected and actual2 == expected)
 
 
+def test_grid_search_cv_nuSVR_multiple_rank1_same_params():
+    iris = datasets.load_iris()
+
+    params1 = {
+        'nu': [0.1],
+        'C': [9, 7],
+        'kernel': ['linear'],
+        'degree': [1],
+        'gamma': [2],
+        'coef0': [3, 0],
+        'shrinking': [True],
+        'tol': [4],
+        'cache_size': [5, 8],
+        'verbose': [True],
+        'max_iter': [6],
+    }
+
+    params2 = {
+        'gamma': [2],
+        'coef0': [0, 3],
+        'shrinking': [True],
+        'verbose': [True],
+        'max_iter': [6],
+        'degree': [1],
+        'tol': [4],
+        'nu': [0.1],
+        'C': [7, 9],
+        'kernel': ['linear'],
+        'cache_size': [8, 5],
+    }
+
+    svr1 = svm.NuSVR()
+    clf1 = GridSearchCV(svr1, params1, return_train_score=True)
+    clf1.fit(iris.data, iris.target)
+
+    svr2 = svm.NuSVR()
+    clf2 = GridSearchCV(svr2, params2, return_train_score=True)
+    clf2.fit(iris.data, iris.target)
+
+    expected = {
+        'C': 9,
+        'cache_size': 5,
+        'coef0': 0,
+        'degree': 1,
+        'gamma': 2,
+        'kernel': 'linear',
+        'max_iter': 6,
+        'nu': 0.1,
+        'shrinking': True,
+        'tol': 4,
+        'verbose': True
+    }
+
+    actual1 = clf1.best_params_
+    actual2 = clf2.best_params_
+
+    assert (actual1 == expected and actual2 == expected)
+
+
+def test_randomized_search_cv_nuSVR_multiple_rank1_same_params():
+    iris = datasets.load_iris()
+
+    params1 = {
+        'nu': [0.1],
+        'C': [9, 7],
+        'kernel': ['linear'],
+        'degree': [1],
+        'gamma': [2],
+        'coef0': [3, 0],
+        'shrinking': [True],
+        'tol': [4],
+        'cache_size': [5, 8],
+        'verbose': [True],
+        'max_iter': [6],
+    }
+
+    params2 = {
+        'gamma': [2],
+        'coef0': [0, 3],
+        'shrinking': [True],
+        'verbose': [True],
+        'max_iter': [6],
+        'degree': [1],
+        'tol': [4],
+        'nu': [0.1],
+        'C': [7, 9],
+        'kernel': ['linear'],
+        'cache_size': [8, 5],
+    }
+
+    svr1 = svm.NuSVR()
+    clf1 = RandomizedSearchCV(svr1, params1, return_train_score=True)
+    clf1.fit(iris.data, iris.target)
+
+    svr2 = svm.NuSVR()
+    clf2 = RandomizedSearchCV(svr2, params2, return_train_score=True)
+    clf2.fit(iris.data, iris.target)
+
+    expected = {
+        'verbose': True,
+        'tol': 4,
+        'shrinking': True,
+        'nu': 0.1,
+        'max_iter': 6,
+        'kernel': 'linear',
+        'gamma': 2,
+        'degree': 1,
+        'coef0': 0,
+        'cache_size': 5,
+        'C': 9
+    }
+
+    actual1 = clf1.best_params_
+    actual2 = clf2.best_params_
+
+    assert (actual1 == expected and actual2 == expected)
+
+
 @pytest.mark.parametrize(
     "SearchCV, param_search",
     [(GridSearchCV, {"a": [0.1, 0.01]}), (RandomizedSearchCV, {"a": uniform(1, 3)})],

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -2469,6 +2469,130 @@ def test_randomized_search_cv_SVR_multiple_rank1_same_params():
     assert actual1 == expected and actual2 == expected
 
 
+def test_grid_search_cv_linearSVC_multiple_rank1_same_params():
+    iris = datasets.load_iris()
+
+    params1 = {
+        'penalty': ['l2'],
+        'loss': ['hinge'],
+        'dual': [True],
+        'tol': [7, 1],
+        'C': [8, 2],
+        'multi_class': ['ovr'],
+        'fit_intercept': [True],
+        'intercept_scaling': [3, 9],
+        'class_weight': ['balanced'],
+        'verbose': [4],
+        'random_state': [5],
+        'max_iter': [6],
+    }
+
+    params2 = {
+        'intercept_scaling': [9, 3],
+        'class_weight': ['balanced'],
+        'multi_class': ['ovr'],
+        'fit_intercept': [True],
+        'loss': ['hinge'],
+        'dual': [True],
+        'C': [2, 8],
+        'verbose': [4],
+        'random_state': [5],
+        'max_iter': [6],
+        'tol': [1, 7],
+        'penalty': ['l2'],
+    }
+
+    svc1 = svm.LinearSVC()
+    clf1 = GridSearchCV(svc1, params1, return_train_score=True)
+    clf1.fit(iris.data, iris.target)
+
+    svc2 = svm.LinearSVC()
+    clf2 = GridSearchCV(svc2, params2, return_train_score=True)
+    clf2.fit(iris.data, iris.target)
+
+    expected = {
+        'C': 2,
+        'class_weight': 'balanced',
+        'dual': True,
+        'fit_intercept': True,
+        'intercept_scaling': 3,
+        'loss': 'hinge',
+        'max_iter': 6,
+        'multi_class': 'ovr',
+        'penalty': 'l2',
+        'random_state': 5,
+        'tol': 1,
+        'verbose': 4
+    }
+
+    actual1 = clf1.best_params_
+    actual2 = clf2.best_params_
+
+    assert (actual1 == expected and actual2 == expected)
+
+
+def test_randomized_search_cv_linearSVC_multiple_rank1_same_params():
+    iris = datasets.load_iris()
+
+    params1 = {
+        'penalty': ['l2'],
+        'loss': ['hinge'],
+        'dual': [True],
+        'tol': [7, 1],
+        'C': [8, 2],
+        'multi_class': ['ovr'],
+        'fit_intercept': [True],
+        'intercept_scaling': [3, 9],
+        'class_weight': ['balanced'],
+        'verbose': [4],
+        'random_state': [5],
+        'max_iter': [6],
+    }
+
+    params2 = {
+        'intercept_scaling': [9, 3],
+        'class_weight': ['balanced'],
+        'multi_class': ['ovr'],
+        'fit_intercept': [True],
+        'loss': ['hinge'],
+        'dual': [True],
+        'C': [2, 8],
+        'verbose': [4],
+        'random_state': [5],
+        'max_iter': [6],
+        'tol': [1, 7],
+        'penalty': ['l2'],
+    }
+
+    svc1 = svm.LinearSVC()
+    clf1 = RandomizedSearchCV(svc1, params1, return_train_score=True)
+    clf1.fit(iris.data, iris.target)
+
+    svc2 = svm.LinearSVC()
+    clf2 = RandomizedSearchCV(svc2, params2, return_train_score=True)
+    clf2.fit(iris.data, iris.target)
+
+    expected = {
+        'verbose': 4,
+        'tol': 1,
+        'random_state': 5,
+        'penalty': 'l2',
+        'multi_class': 'ovr',
+        'max_iter': 6,
+        'loss': 'hinge',
+        'intercept_scaling': 3,
+        'fit_intercept': True,
+        'dual': True,
+        'class_weight': 'balanced',
+        'C': 2
+    }
+
+    actual1 = clf1.best_params_
+    actual2 = clf2.best_params_
+
+    assert (actual1 == expected and actual2 == expected)
+
+
 @pytest.mark.parametrize(
     "SearchCV, param_search",
     [(GridSearchCV, {"a": [0.1, 0.01]}), (RandomizedSearchCV, {"a": uniform(1, 3)})],

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -12,6 +12,7 @@ import re
 import numpy as np
 import scipy.sparse as sp
 import pytest
+from sklearn import svm, datasets
 
 from sklearn.utils._testing import (
     assert_array_equal,
@@ -2266,6 +2267,89 @@ def test_search_cv_pairwise_property_equivalence_of_precomputed():
 
     attr_message = "GridSearchCV not identical with precomputed metric"
     assert (preds_original == preds_precomputed).all(), attr_message
+
+
+def test_grid_search_cv_SVC_multiple_rank1_same_params():
+    iris = datasets.load_iris()
+    params1 = {
+        'C': [1, 101],
+        'break_ties': [False],
+        'cache_size': [2, 102],
+        'class_weight': ['balanced'],
+        'coef0': [3, 103],
+        'decision_function_shape': ['ovo', 'ovr'],
+    }
+
+    params2 = {
+        'decision_function_shape': ['ovr', 'ovo'],
+        'cache_size': [102, 2],
+        'class_weight': ['balanced'],
+        'C': [1, 101],
+        'break_ties': [False],
+        'coef0': [103, 3],
+    }
+
+    svc1 = svm.SVC()
+    clf1 = GridSearchCV(svc1, params1, return_train_score=True)
+    clf1.fit(iris.data, iris.target)
+
+    svc2 = svm.SVC()
+    clf2 = GridSearchCV(svc2, params2, return_train_score=True)
+    clf2.fit(iris.data, iris.target)
+
+    expected = {
+        'C': 101,
+        'break_ties': False,
+        'cache_size': 102,
+        'class_weight': 'balanced',
+        'coef0': 103,
+        'decision_function_shape': 'ovo'
+    }
+
+    actual1 = clf1.best_params_
+    actual2 = clf2.best_params_
+
+    assert (actual1 == expected and actual2 == expected)
+
+
+def test_randomized_search_cv_SVC_multiple_rank1_same_params():
+    iris = datasets.load_iris()
+    params1 = {
+        'C': [1, 101],
+        'break_ties': [False],
+        'cache_size': [2, 102],
+        'class_weight': ['balanced'],
+        'decision_function_shape': ['ovo', 'ovr'],
+    }
+
+    params2 = {
+        'decision_function_shape': ['ovr', 'ovo'],
+        'cache_size': [102, 2],
+        'class_weight': ['balanced'],
+        'C': [1, 101],
+        'break_ties': [False],
+    }
+
+    svc1 = svm.SVC()
+    clf1 = RandomizedSearchCV(svc1, params1, return_train_score=True)
+    clf1.fit(iris.data, iris.target)
+
+    svc2 = svm.SVC()
+    clf2 = RandomizedSearchCV(svc2, params2, return_train_score=True)
+    clf2.fit(iris.data, iris.target)
+
+    expected = {
+        'decision_function_shape': 'ovo',
+        'class_weight': 'balanced',
+        'cache_size': 102,
+        'break_ties': False,
+        'C': 101
+    }
+
+    actual1 = clf1.best_params_
+    actual2 = clf2.best_params_
+
+    assert (actual1 == expected and actual2 == expected)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -2443,11 +2443,11 @@ def test_randomized_search_cv_SVR_multiple_rank1_same_params():
     }
 
     svr1 = svm.SVR()
-    clf1 = GridSearchCV(svr1, params1, return_train_score=True)
+    clf1 = RandomizedSearchCV(svr1, params1, return_train_score=True)
     clf1.fit(iris.data, iris.target)
 
     svr2 = svm.SVR()
-    clf2 = GridSearchCV(svr2, params2, return_train_score=True)
+    clf2 = RandomizedSearchCV(svr2, params2, return_train_score=True)
     clf2.fit(iris.data, iris.target)
 
     expected = {
@@ -2687,16 +2687,158 @@ def test_randomized_search_cv_linearSVR_multiple_rank1_same_params():
     clf2.fit(iris.data, iris.target)
 
     expected = {
-        'verbose': 4, 
-        'tol': 1, 
-        'random_state': 5, 
-        'max_iter': 6, 
-        'loss': 'epsilon_insensitive', 
-        'intercept_scaling': 3, 
-        'fit_intercept': True, 
-        'epsilon': 0, 
-        'dual': True, 
+        'verbose': 4,
+        'tol': 1,
+        'random_state': 5,
+        'max_iter': 6,
+        'loss': 'epsilon_insensitive',
+        'intercept_scaling': 3,
+        'fit_intercept': True,
+        'epsilon': 0,
+        'dual': True,
         'C': 2
+    }
+
+    actual1 = clf1.best_params_
+    actual2 = clf2.best_params_
+
+    assert (actual1 == expected and actual2 == expected)
+
+
+def test_grid_search_cv_nuSVC_multiple_rank1_same_params():
+    iris = datasets.load_iris()
+
+    params1 = {
+        'nu': [0.1],
+        'kernel': ['linear'],
+        'degree': [1],
+        'gamma': [2],
+        'coef0': [3],
+        'shrinking': [True],
+        'probability': [True, False],
+        'tol': [4],
+        'cache_size': [5],
+        'class_weight': ['balanced'],
+        'verbose': [True],
+        'max_iter': [6],
+        'decision_function_shape': ['ovo', 'ovr'],
+        'break_ties': [False],
+        'random_state': [8, 9],
+    }
+
+    params2 = {
+        'max_iter': [6],
+        'decision_function_shape': ['ovr', 'ovo'],
+        'break_ties': [False],
+        'random_state': [9, 8],
+        'coef0': [3],
+        'probability': [False, True],
+        'tol': [4],
+        'cache_size': [5],
+        'class_weight': ['balanced'],
+        'verbose': [True],
+        'nu': [0.1],
+        'kernel': ['linear'],
+        'shrinking': [True],
+        'degree': [1],
+        'gamma': [2],
+    }
+
+    svc1 = svm.NuSVC()
+    clf1 = GridSearchCV(svc1, params1, return_train_score=True)
+    clf1.fit(iris.data, iris.target)
+
+    svc2 = svm.NuSVC()
+    clf2 = GridSearchCV(svc2, params2, return_train_score=True)
+    clf2.fit(iris.data, iris.target)
+
+    expected = {
+        'break_ties': False,
+        'cache_size': 5,
+        'class_weight': 'balanced',
+        'coef0': 3,
+        'decision_function_shape': 'ovo',
+        'degree': 1,
+        'gamma': 2,
+        'kernel': 'linear',
+        'max_iter': 6,
+        'nu': 0.1,
+        'probability': False,
+        'random_state': 8,
+        'shrinking': True,
+        'tol': 4,
+        'verbose': True
+    }
+
+    actual1 = clf1.best_params_
+    actual2 = clf2.best_params_
+
+    assert (actual1 == expected and actual2 == expected)
+
+
+def test_randomized_search_cv_nuSVC_multiple_rank1_same_params():
+    iris = datasets.load_iris()
+
+    params1 = {
+        'nu': [0.1],
+        'kernel': ['linear'],
+        'degree': [1],
+        'gamma': [2],
+        'coef0': [3],
+        'shrinking': [True],
+        'probability': [True, False],
+        'tol': [4],
+        'cache_size': [5],
+        'class_weight': ['balanced'],
+        'verbose': [True],
+        'max_iter': [6],
+        'decision_function_shape': ['ovo', 'ovr'],
+        'break_ties': [False],
+        'random_state': [8, 9],
+    }
+
+    params2 = {
+        'max_iter': [6],
+        'decision_function_shape': ['ovr', 'ovo'],
+        'break_ties': [False],
+        'random_state': [9, 8],
+        'coef0': [3],
+        'probability': [False, True],
+        'tol': [4],
+        'cache_size': [5],
+        'class_weight': ['balanced'],
+        'verbose': [True],
+        'nu': [0.1],
+        'kernel': ['linear'],
+        'shrinking': [True],
+        'degree': [1],
+        'gamma': [2],
+    }
+
+    svc1 = svm.NuSVC()
+    clf1 = RandomizedSearchCV(svc1, params1, return_train_score=True)
+    clf1.fit(iris.data, iris.target)
+
+    svc2 = svm.NuSVC()
+    clf2 = RandomizedSearchCV(svc2, params2, return_train_score=True)
+    clf2.fit(iris.data, iris.target)
+
+    expected = {
+        'verbose': True,
+        'tol': 4,
+        'shrinking': True,
+        'random_state': 8,
+        'probability': False,
+        'nu': 0.1,
+        'max_iter': 6,
+        'kernel': 'linear',
+        'gamma': 2,
+        'degree': 1,
+        'decision_function_shape': 'ovo',
+        'coef0': 3,
+        'class_weight': 'balanced',
+        'cache_size': 5,
+        'break_ties': False
     }
 
     actual1 = clf1.best_params_

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -2352,6 +2352,123 @@ def test_randomized_search_cv_SVC_multiple_rank1_same_params():
     assert (actual1 == expected and actual2 == expected)
 
 
+def test_grid_search_cv_SVR_multiple_rank1_same_params():
+    iris = datasets.load_iris()
+
+    params1 = {
+        'kernel': ['linear'],
+        'degree': [1, 2],
+        'gamma': ['scale'],
+        'coef0': [3, 4],
+        'tol': [5],
+        'C': [6],
+        'epsilon': [7],
+        'shrinking': [True],
+        'cache_size': [8],
+        'verbose': [True],
+        'max_iter': [9],
+    }
+
+    params2 = {
+        'tol': [5],
+        'C': [6],
+        'verbose': [True],
+        'degree': [1, 2],
+        'epsilon': [7],
+        'shrinking': [True],
+        'cache_size': [8],
+        'kernel': ['linear'],
+        'gamma': ['scale'],
+        'coef0': [3, 4],
+        'max_iter': [9]
+    }
+
+    svr1 = svm.SVR()
+    clf1 = GridSearchCV(svr1, params1, return_train_score=True)
+    clf1.fit(iris.data, iris.target)
+
+    svr2 = svm.SVR()
+    clf2 = GridSearchCV(svr2, params2, return_train_score=True)
+    clf2.fit(iris.data, iris.target)
+
+    expected = {
+        'C': 6,
+        'cache_size': 8,
+        'coef0': 3,
+        'degree': 1,
+        'epsilon': 7,
+        'gamma': 'scale',
+        'kernel': 'linear',
+        'max_iter': 9,
+        'shrinking': True,
+        'tol': 5,
+        'verbose': True
+    }
+
+    actual1 = clf1.best_params_
+    actual2 = clf2.best_params_
+
+    assert (actual1 == expected and actual2 == expected)
+
+
+def test_randomized_search_cv_SVR_multiple_rank1_same_params():
+    iris = datasets.load_iris()
+
+    params1 = {
+        'kernel': ['linear'],
+        'degree': [1, 2],
+        'gamma': ['scale'],
+        'coef0': [3, 4],
+        'tol': [5],
+        'C': [6],
+        'epsilon': [7],
+        'shrinking': [True],
+        'cache_size': [8],
+        'verbose': [True],
+        'max_iter': [9],
+    }
+
+    params2 = {
+        'tol': [5],
+        'C': [6],
+        'verbose': [True],
+        'degree': [1, 2],
+        'epsilon': [7],
+        'shrinking': [True],
+        'cache_size': [8],
+        'kernel': ['linear'],
+        'gamma': ['scale'],
+        'coef0': [3, 4],
+        'max_iter': [9]
+    }
+
+    svr1 = svm.SVR()
+    clf1 = GridSearchCV(svr1, params1, return_train_score=True)
+    clf1.fit(iris.data, iris.target)
+
+    svr2 = svm.SVR()
+    clf2 = GridSearchCV(svr2, params2, return_train_score=True)
+    clf2.fit(iris.data, iris.target)
+
+    expected = {
+        'verbose': True,
+        'tol': 5,
+        'shrinking': True,
+        'max_iter': 9,
+        'kernel': 'linear',
+        'gamma': 'scale',
+        'epsilon': 7,
+        'degree': 1,
+        'coef0': 3,
+        'cache_size': 8,
+        'C': 6}
+
+    actual1 = clf1.best_params_
+    actual2 = clf2.best_params_
+
+    assert actual1 == expected and actual2 == expected
+
+
 @pytest.mark.parametrize(
     "SearchCV, param_search",
     [(GridSearchCV, {"a": [0.1, 0.01]}), (RandomizedSearchCV, {"a": uniform(1, 3)})],


### PR DESCRIPTION
####Reference Issues/PRs
Fixes https://github.com/scikit-learn/scikit-learn/issues/21895

####What does this implement/fix? Explain your changes.
When there are multiple params with rank=1, GridSearchCV and RandomizedSearchCV fit.best_params_ would return the first one in the order params appear in the list. However, when given the exact same params in different order, fit.best_params_ might return a different param, creating an ambiguity.

To solve this issue, lexicographical order of the params are considered instead of the order they appear in the list. In this way, independent from the order params are given, fit.best_params_ will return exactly the same output.

Lexicographical order is decided with the attributes of the estimators being used and order is calculated with _hash_param_values method.
